### PR TITLE
Add-new-command-line-options-for-word-list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 👷 ci(circleci)-update toolkit orb source(pr [#6])
 - Add-words-struct-for-word-list-preparation(pr [#7])
 - Add-LettersBoxed-struct(pr [#8])
+- Add-new-command-line-options-for-word-list(pr [#11])
 
 ### Fixed
 
@@ -26,3 +27,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#8]: https://github.com/jerus-org/slb/pull/8
 [#9]: https://github.com/jerus-org/slb/pull/9
 [#10]: https://github.com/jerus-org/slb/pull/10
+[#11]: https://github.com/jerus-org/slb/pull/11

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,5 +15,5 @@ pub struct Cli {
     pub file: Option<String>,
     /// minimum word length
     #[arg(short, long)]
-    pub minimum: Option<String>,
+    pub minimum: Option<usize>,
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,4 +7,13 @@ pub struct Cli {
     /// logging level
     #[clap(flatten)]
     pub logging: Verbosity,
+    /// word list source directory
+    #[arg(short, long)]
+    pub dir: Option<String>,
+    /// word list source file
+    #[arg(short, long)]
+    pub file: Option<String>,
+    /// minimum word length
+    #[arg(short, long)]
+    pub minimum: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,9 +30,9 @@ fn main() {
     }
 
     // Setup settings
-    let src_directory = DEFAULT_SOURCE_DIR;
-    let src_file = DEFAULT_SOURCE_FILE;
-    let minimum_word_length = DEFAULT_MINIMUM_WORD_LENGTH;
+    let src_directory = args.dir.unwrap_or(DEFAULT_SOURCE_DIR.to_string());
+    let src_file = args.file.unwrap_or(DEFAULT_SOURCE_FILE.to_string());
+    let minimum_word_length = args.minimum.unwrap_or(DEFAULT_MINIMUM_WORD_LENGTH);
 
     let src = format!("{src_directory}/{src_file}");
 


### PR DESCRIPTION
♻️ refactor(main): enhance configuration with argument support

- use command line arguments for source directory, file, and minimum word length
- maintain default values for these configurations if arguments are not provided

🐛 fix(cli): correct minimum type in CLI struct

- change minimum field type from Option<String> to Option<usize> to ensure correct data handling and prevent potential runtime errors.

✨ feat(cli): add new command line options for word list

- add dir option for specifying word list source directory
- add file option for specifying word list source file
- add minimum option for setting minimum word length