### PR TITLE
✨ feat(cli): add shuffle count option for word chain building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ✨ add randomness to word chain building(pr [#26])
 - ✨ add shuffle iterations option(pr [#27])
+- ✨ add shuffle count option for word chain building(pr [#28])
 
 ## [0.1.4] - 2025-03-27
 
@@ -91,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#25]: https://github.com/jerus-org/slb/pull/25
 [#26]: https://github.com/jerus-org/slb/pull/26
 [#27]: https://github.com/jerus-org/slb/pull/27
+[#28]: https://github.com/jerus-org/slb/pull/28
 [Unreleased]: https://github.com/jerus-org/slb/compare/v0.1.4...HEAD
 [0.1.4]: https://github.com/jerus-org/slb/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/jerus-org/slb/compare/v0.1.2...v0.1.3

--- a/src/cli/solve.rs
+++ b/src/cli/solve.rs
@@ -82,7 +82,7 @@ impl CmdSolve {
         match puzzle
             .filter_words_with_letters_only()
             .filter_words_with_invalid_pairs()
-            .build_word_chain(!self.no_shuffle)
+            .build_word_chain(!self.no_shuffle, self.shuffles)
         {
             Ok(_) => {
                 tracing::info!("Word chain built successfully");


### PR DESCRIPTION
- extend `build_word_chain` to accept optional shuffle count
- enhance word chain logic to decrement shuffle count with each use
- add tracing info for shuffle operations and shuffle count