### PR TITLE
✨ feat(cli): add twice shuffle option to command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ✨ add twice shuffle option to command(pr [#29])
+
 ## [0.1.5] - 2025-03-31
 
 ### Added
@@ -93,6 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#26]: https://github.com/jerus-org/slb/pull/26
 [#27]: https://github.com/jerus-org/slb/pull/27
 [#28]: https://github.com/jerus-org/slb/pull/28
+[#29]: https://github.com/jerus-org/slb/pull/29
+[Unreleased]: https://github.com/jerus-org/slb/compare/v0.1.5...HEAD
 [0.1.5]: https://github.com/jerus-org/slb/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/jerus-org/slb/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/jerus-org/slb/compare/v0.1.2...v0.1.3

--- a/src/cli/solve.rs
+++ b/src/cli/solve.rs
@@ -22,6 +22,13 @@ pub struct CmdSolve {
     /// number of iterations to shuffle
     #[arg(short, long)]
     pub shuffles: Option<usize>,
+    /// shuffle the whole word list and weighted list
+    #[arg(
+        short,
+        long,
+        long_help = "Shuffle the whole word list before calculating weightings\nthen shuffle the top half of the weighted word list."
+    )]
+    pub twice: bool,
 }
 
 impl CmdSolve {
@@ -82,7 +89,7 @@ impl CmdSolve {
         match puzzle
             .filter_words_with_letters_only()
             .filter_words_with_invalid_pairs()
-            .build_word_chain(!self.no_shuffle, self.shuffles)
+            .build_word_chain(!self.no_shuffle, self.shuffles, self.twice)
         {
             Ok(_) => {
                 tracing::info!("Word chain built successfully");

--- a/src/letters_boxed.rs
+++ b/src/letters_boxed.rs
@@ -104,11 +104,12 @@ impl LettersBoxed {
         self
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(skip(self, shuffle, shuffles, twice))]
     pub fn build_word_chain(
         &mut self,
         shuffle: bool,
         shuffles: Option<usize>,
+        twice: bool,
     ) -> Result<(), Error> {
         tracing::info!("Building word chain");
         // Get the first word from the list of words
@@ -126,6 +127,7 @@ impl LettersBoxed {
             &mut rng,
             shuffle,
             shuffles,
+            twice,
         )?;
 
         self.word_chain = word_chain;
@@ -138,7 +140,17 @@ impl LettersBoxed {
     }
 }
 
-#[tracing::instrument(skip(all_words, words_list))]
+#[allow(clippy::too_many_arguments)]
+#[tracing::instrument(skip(
+    all_words,
+    words_list,
+    word_chain,
+    unused_letters,
+    rng,
+    shuffle,
+    shuffles,
+    twice
+))]
 pub fn get_word(
     all_words: Vec<String>,
     mut words_list: Vec<String>,
@@ -147,6 +159,7 @@ pub fn get_word(
     rng: &mut ChaCha20Rng,
     shuffle: bool,
     mut shuffles: Option<usize>,
+    twice: bool,
 ) -> Result<Vec<String>, Error> {
     let initial_unused_letters = unused_letters.clone();
 
@@ -155,7 +168,7 @@ pub fn get_word(
 
     // Shuffle the starting words list to get a random starting word
     tracing::trace!("List before shuffle: {:#?}", &words_list[0..5]);
-    if shuffle && shuffle_count > 0 {
+    if shuffle && shuffle_count > 0 && twice {
         tracing::info!("Shuffling words list.");
         words_list.shuffle(rng);
         tracing::trace!("List after shuffle: {:#?}", &words_list[0..5]);
@@ -271,6 +284,7 @@ pub fn get_word(
                 rng,
                 shuffle,
                 shuffles,
+                twice,
             ) {
                 Ok(chain) => {
                     word_chain = chain;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
             let settings = settings
                 .try_deserialize::<HashMap<String, String>>()
                 .unwrap();
-            tracing::info!("Loaded settings: {:?}", settings);
+            tracing::debug!("Loaded settings: {:?}", settings);
             match args.cmd {
                 Commands::Prepare(prepare) => prepare.run(settings),
                 Commands::Solve(solve) => solve.run(settings),
@@ -48,7 +48,8 @@ pub fn get_logging(verbosity: log::LevelFilter) {
     ));
 
     let log_subscriber = tracing_subscriber::FmtSubscriber::builder()
-        .pretty()
+        // .pretty()
+        .compact()
         .with_env_filter(filter)
         .finish();
 

--- a/tests/cmd/help.trycmd
+++ b/tests/cmd/help.trycmd
@@ -76,16 +76,34 @@ Solve word puzzle
 Usage: slb solve [OPTIONS] [LETTERS]...
 
 Arguments:
-  [LETTERS]...  
+  [LETTERS]...
+          
 
 Options:
-  -d, --dir <DIR>            word list source directory
-  -v, --verbose...           Increase logging verbosity
-  -f, --file <FILE>          word list source file
-  -q, --quiet...             Decrease logging verbosity
-  -n, --no-shuffle           do not shuffle the words
-  -s, --shuffles <SHUFFLES>  number of iterations to shuffle
-  -h, --help                 Print help
+  -d, --dir <DIR>
+          word list source directory
+
+  -v, --verbose...
+          Increase logging verbosity
+
+  -f, --file <FILE>
+          word list source file
+
+  -q, --quiet...
+          Decrease logging verbosity
+
+  -n, --no-shuffle
+          do not shuffle the words
+
+  -s, --shuffles <SHUFFLES>
+          number of iterations to shuffle
+
+  -t, --twice
+          Shuffle the whole word list before calculating weightings
+          then shuffle the top half of the weighted word list.
+
+  -h, --help
+          Print help (see a summary with '-h')
 
 ```
 
@@ -105,7 +123,8 @@ Options:
   -q, --quiet...             Decrease logging verbosity
   -n, --no-shuffle           do not shuffle the words
   -s, --shuffles <SHUFFLES>  number of iterations to shuffle
-  -h, --help                 Print help
+  -t, --twice                shuffle the whole word list and weighted list
+  -h, --help                 Print help (see more with '--help')
 
 ```
 


### PR DESCRIPTION
- introduce a 'twice' flag to shuffle the whole word list before calculating weightings
- shuffle the top half of the weighted word list for improved word chain building