### PR TITLE
🔧 chore(workspace): update Cargo.toml for workspace configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - restructure project into a workspace(pr [#33])
 - Add-max-chain-length-option-for-solutions(pr [#37])
+- 🔧 chore(workspace)-update Cargo.toml for workspace configuration(pr [#38])
 
 ### Security
 
@@ -135,6 +136,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#35]: https://github.com/jerus-org/slb/pull/35
 [#36]: https://github.com/jerus-org/slb/pull/36
 [#37]: https://github.com/jerus-org/slb/pull/37
+[#38]: https://github.com/jerus-org/slb/pull/38
 [Unreleased]: https://github.com/jerus-org/slb/compare/v0.1.8...HEAD
 [0.1.8]: https://github.com/jerus-org/slb/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/jerus-org/slb/compare/v0.1.6...v0.1.7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ rust-version = "1.85"
 repository = "https://github.com/jerus-org/slb"
 keywords = ["letters", "boxed", "nyt", "solver"]
 categories = ["puzzle-solver"]
+license = "MIT"
+readme = "README.md"
 
 [workspace.dependencies]
 clap = { version = "4.5.32", features = ["derive"] }

--- a/crates/slb-cli/Cargo.toml
+++ b/crates/slb-cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "slb-cli"
 version = "0.1.8"
-edition = "2024"
-authors = ["jerusdp <jrussell@jerus.ie>"]
-description = "Solve the NYT Letters Boxed puzzle"
-license = "MIT"
-readme = "README.md"
+edition.workspace = true
+authors.workspace = true
+description = "Command line program to solve the NYT Letters Boxed puzzle"
+license.workspace = true
+readme.workspace = true
 repository = "https://github.com/jerus-org/slb"
 keywords = ["letters", "boxed", "nyt", "solver"]
 categories = ["puzzle-solver"]

--- a/crates/slb-cli/tests/cmd/help.trycmd
+++ b/crates/slb-cli/tests/cmd/help.trycmd
@@ -1,6 +1,6 @@
 ```console
 $ slb --help
-Solve the NYT Letters Boxed puzzle
+Command line program to solve the NYT Letters Boxed puzzle
 
 Usage: slb [OPTIONS] <COMMAND>
 
@@ -21,7 +21,7 @@ Options:
 
 ```console
 $ slb -h
-Solve the NYT Letters Boxed puzzle
+Command line program to solve the NYT Letters Boxed puzzle
 
 Usage: slb [OPTIONS] <COMMAND>
 

--- a/crates/slb-cli/tests/cmd/run.trycmd
+++ b/crates/slb-cli/tests/cmd/run.trycmd
@@ -1,7 +1,7 @@
 ```console
 $ slb 
 ? 2
-Solve the NYT Letters Boxed puzzle
+Command line program to solve the NYT Letters Boxed puzzle
 
 Usage: slb [OPTIONS] <COMMAND>
 

--- a/crates/slb/Cargo.toml
+++ b/crates/slb/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "slb"
 version = "0.1.8"
-edition = "2024"
-authors = ["jerusdp <jrussell@jerus.ie>"]
-description = "Solve the NYT Letters Boxed puzzle"
-license = "MIT"
-readme = "README.md"
+edition.workspace = true
+authors.workspace = true
+description = "Library to solve the NYT Letters Boxed puzzle"
+license.workspace = true
+readme.workspace = true
 repository = "https://github.com/jerus-org/slb"
 keywords = ["letters", "boxed", "nyt", "solver"]
 categories = ["puzzle-solver"]


### PR DESCRIPTION
- set edition, authors, license, and readme fields to workspace
- update description for slb and slb-cli packages