### PR TITLE
✨ feat(cli): add bare option for letter output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ✨ add generate command(pr [#43])
+- ✨ add bare option for letter output(pr [#44])
 
 ## [0.1.11] - 2025-04-02
 
@@ -162,6 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#41]: https://github.com/jerus-org/slb/pull/41
 [#42]: https://github.com/jerus-org/slb/pull/42
 [#43]: https://github.com/jerus-org/slb/pull/43
+[#44]: https://github.com/jerus-org/slb/pull/44
 [Unreleased]: https://github.com/jerus-org/slb/compare/v0.1.11...HEAD
 [0.1.11]: https://github.com/jerus-org/slb/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/jerus-org/slb/compare/v0.1.9...v0.1.10

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -10,6 +10,9 @@ const ALPHABET: &str = "abcdefghijklmnopqrstuvwxyz";
 #[derive(Parser, Debug, Clone)]
 pub struct Cmd {
     pub shape: Shape,
+    // Bare result listing the letters for the puzzle only
+    #[arg(short, long)]
+    pub bare: bool,
     // Testing
     #[arg(long, hide = true)]
     pub testing: bool,
@@ -27,7 +30,11 @@ impl Cmd {
             .collect::<String>();
 
         if !self.testing {
-            println!("Letters for edges of the {} are: `{}`", self.shape, letters);
+            if self.bare {
+                println!("{}", letters);
+            } else {
+                println!("Letters for edges of the {} are: `{}`", self.shape, letters);
+            }
         }
 
         Ok(())

--- a/tests/cmd/help.trycmd
+++ b/tests/cmd/help.trycmd
@@ -210,6 +210,7 @@ Arguments:
   <SHAPE>  
 
 Options:
+  -b, --bare        
   -v, --verbose...  Increase logging verbosity
   -q, --quiet...    Decrease logging verbosity
   -h, --help        Print help
@@ -226,6 +227,7 @@ Arguments:
   <SHAPE>  
 
 Options:
+  -b, --bare        
   -v, --verbose...  Increase logging verbosity
   -q, --quiet...    Decrease logging verbosity
   -h, --help        Print help


### PR DESCRIPTION
- introduce a `bare` flag to print letters without additional text
- enhance flexibility in how puzzle letters are displayed