### PR TITLE
✨ feat(cli): add shuffle depth option for word chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ✨ add shuffle depth option for word chain(pr [#46])
+
 ## [0.1.12] - 2025-04-03
 
 ### Added
@@ -166,6 +172,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#43]: https://github.com/jerus-org/slb/pull/43
 [#44]: https://github.com/jerus-org/slb/pull/44
 [#45]: https://github.com/jerus-org/slb/pull/45
+[#46]: https://github.com/jerus-org/slb/pull/46
+[Unreleased]: https://github.com/jerus-org/slb/compare/v0.1.12...HEAD
 [0.1.12]: https://github.com/jerus-org/slb/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/jerus-org/slb/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/jerus-org/slb/compare/v0.1.9...v0.1.10

--- a/src/cli/solutions.rs
+++ b/src/cli/solutions.rs
@@ -21,6 +21,9 @@ pub struct CmdSolutions {
     /// maximum length of the word chain
     #[arg(short, long, default_value_t = 10)]
     pub max_chain: usize,
+    /// Shuffle depth
+    #[arg(short, long, default_value_t = 3)]
+    pub shuffle_depth: i8,
 }
 
 impl CmdSolutions {
@@ -98,8 +101,8 @@ impl CmdSolutions {
 
         let mut shuffle = Shuffle::Once;
         let mut max_clashes = 10;
-        // let mut max_solutions = self.random_solutions;
-        let mut max_solutions = 200;
+        let mut max_solutions = self.random_solutions;
+        // let mut max_solutions = 200;
 
         while max_solutions > 0 && max_clashes > 0 {
             tracing::info!(
@@ -110,6 +113,7 @@ impl CmdSolutions {
                 .filter_words_with_letters_only()
                 .filter_words_with_invalid_pairs()
                 .set_max_chain(self.max_chain)
+                .set_shuffle_depth(self.shuffle_depth)
                 .build_word_chain(&mut shuffle)
             {
                 Ok(_) => {

--- a/tests/cmd/help.trycmd
+++ b/tests/cmd/help.trycmd
@@ -173,6 +173,7 @@ Options:
   -q, --quiet...                             Decrease logging verbosity
   -r, --random-solutions <RANDOM_SOLUTIONS>  number of random solutions to generate [default: 100]
   -m, --max-chain <MAX_CHAIN>                maximum length of the word chain [default: 10]
+  -s, --shuffle-depth <SHUFFLE_DEPTH>        Shuffle depth [default: 3]
   -h, --help                                 Print help
 
 ```
@@ -193,6 +194,7 @@ Options:
   -q, --quiet...                             Decrease logging verbosity
   -r, --random-solutions <RANDOM_SOLUTIONS>  number of random solutions to generate [default: 100]
   -m, --max-chain <MAX_CHAIN>                maximum length of the word chain [default: 10]
+  -s, --shuffle-depth <SHUFFLE_DEPTH>        Shuffle depth [default: 3]
   -h, --help                                 Print help
 
 ```


### PR DESCRIPTION
- introduce shuffle depth parameter to control the randomness in word chain generation
- update command line interface with new shuffle depth option

✅ test(help): update help command tests with new shuffle depth option

- add shuffle depth option to help command test to ensure correct display and functionality