### PR TITLE
♻️ refactor(project): rename PrepareWords to WordFilters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ♻️ refactor(modules)-reorganize module structure(pr [#54])
 - ♻️ BREAKING: refactor(cli)-consolidate puzzle commands under boxed module(pr [#55])
+- ♻️ refactor(project)-rename PrepareWords to WordFilters(pr [#58])
 
 ## [0.1.14] - 2025-04-07
 
@@ -211,6 +212,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#55]: https://github.com/jerus-org/slb/pull/55
 [#56]: https://github.com/jerus-org/slb/pull/56
 [#57]: https://github.com/jerus-org/slb/pull/57
+[#58]: https://github.com/jerus-org/slb/pull/58
 [Unreleased]: https://github.com/jerus-org/slb/compare/v0.1.14...HEAD
 [0.1.14]: https://github.com/jerus-org/slb/compare/v0.1.13...v0.1.14
 [0.1.13]: https://github.com/jerus-org/slb/compare/v0.1.12...v0.1.13

--- a/src/cli/alpha.rs
+++ b/src/cli/alpha.rs
@@ -7,7 +7,7 @@ use std::{
 
 use clap::Parser;
 
-use crate::{Error, PrepareWords};
+use crate::{Error, WordFilters};
 
 const DEFAULT_SOURCE_DIR: &str = "words";
 const DEFAULT_SOURCE_FILE: &str = "wiki-100k.txt";

--- a/src/cli/boxed/prepare.rs
+++ b/src/cli/boxed/prepare.rs
@@ -2,7 +2,7 @@ use std::{collections::VecDeque, io::Write, path::PathBuf, str::FromStr};
 
 use clap::Parser;
 
-use crate::{Error, PrepareWords};
+use crate::{Error, WordFilters};
 
 const DEFAULT_SOURCE_DIR: &str = "words";
 const DEFAULT_SOURCE_FILE: &str = "mit_words.txt";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,13 @@
 mod boxed;
 mod cli;
 mod error;
-mod prepare_words;
+mod word_filters;
 mod words;
 
 pub use boxed::{LettersBoxed, Shape, Shuffle, Solution};
 pub use cli::{Cli, Commands};
 pub use error::Error;
-pub use prepare_words::PrepareWords;
+pub use word_filters::WordFilters;
 pub use words::Words;
 
 pub const DEFAULT_SOURCE_DIR: &str = "/usr/lib/slb/words";

--- a/src/word_filters.rs
+++ b/src/word_filters.rs
@@ -1,13 +1,13 @@
 //! Prepares a list of words from a file for use in by the solver.
 
-pub trait PrepareWords {
+pub trait WordFilters {
     fn filter_to_minimum_length(self, length: usize) -> Self;
     fn filter_no_repeated_letters(self) -> Self;
     fn filter_excludes_letters(self, exclude: &str) -> Self;
     fn filter_includes_letters(self, exclude: &str) -> Self;
 }
 
-impl PrepareWords for Vec<String> {
+impl WordFilters for Vec<String> {
     #[tracing::instrument(skip(self))]
     fn filter_to_minimum_length(self, length: usize) -> Self {
         let filtered = self
@@ -128,7 +128,7 @@ mod tests {
         assert_eq!(failed, vec!["aa", "all", "success", "greatness"]);
     }
 
-    use super::PrepareWords;
+    use super::WordFilters;
 
     #[test]
     fn test_filter_exclude_letters() {

--- a/src/words.rs
+++ b/src/words.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use colorful::Colorful;
 
-use crate::{DEFAULT_SOURCE_DIR, DEFAULT_WORDS_SOURCE_FILE, Error, PrepareWords};
+use crate::{DEFAULT_SOURCE_DIR, DEFAULT_WORDS_SOURCE_FILE, Error, WordFilters};
 
 #[derive(Debug, Default)]
 pub struct Words {


### PR DESCRIPTION
- rename module and trait from PrepareWords to WordFilters for clarity
- update all references and imports across the project to reflect the new naming